### PR TITLE
Normalize blocks so each block equal one version

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,10 @@ var sub = require('subleveldown')
 var normalize = through2.obj(function (change, env, cb) {
   var stream = this
   var doc = change.doc
-  var next = afterAll(cb)
+  var next = afterAll(function (err) {
+    if (err) return cb(err)
+    index.put('!latest_seq!', change.seq, cb)
+  })
 
   clean(doc)
 
@@ -29,10 +32,7 @@ var normalize = through2.obj(function (change, env, cb) {
       index.get(key, function (err, value) {
         if (!err || !err.notFound) return done(err)
         stream.push(doc.versions[version])
-        index.put(key, true, function (err) {
-          if (err) return done(err)
-          index.put('!latest_seq!', change.seq, done)
-        })
+        index.put(key, true, done)
       })
     })
   }

--- a/index.js
+++ b/index.js
@@ -1,11 +1,30 @@
 'use strict'
 
 var ChangesStream = require('changes-stream')
+var clean = require('normalize-registry-metadata')
+var through2 = require('through2')
 var hypercore = require('hypercore')
 var swarm = require('hyperdrive-archive-swarm')
 var ndjson = require('ndjson')
 var pump = require('pump')
 var levelup = require('level')
+
+var normalize = through2.obj(function (change, env, cb) {
+  var stream = this
+  var doc = clean(change.doc)
+
+  if (!doc) {
+    console.log('skipping %s - invalid document', change.id)
+  } else if (!doc.versions || doc.versions.length === 0) {
+    console.log('skipping %s - no versions detected', change.id)
+  } else {
+    Object.keys(doc.versions).forEach(function (version) {
+      stream.push(doc.versions[version])
+    })
+  }
+
+  cb()
+})
 
 var db = levelup(process.argv[2] || './npm-to-hypercore.db')
 var core = hypercore(db)
@@ -27,12 +46,12 @@ core.list(function (err, keys) {
     var stream = feed.createWriteStream()
 
     if (feed.blocks === 0) {
-      pump(changesSinceStream(), stream, run)
+      pump(changesSinceStream(), normalize, ndjson.serialize(), stream, run)
     } else {
       feed.get(feed.blocks - 1, function (err, block) {
         if (err) throw err
         var seq = JSON.parse(block).seq
-        pump(changesSinceStream(seq), stream, run)
+        pump(changesSinceStream(seq), normalize, ndjson.serialize(), stream, run)
       })
     }
   }
@@ -43,12 +62,10 @@ function changesSinceStream (seq) {
 
   console.log('feching changes since sequence #%s', seq)
 
-  var changes = new ChangesStream({
+  return new ChangesStream({
     db: 'https://replicate.npmjs.com',
     include_docs: true,
     since: seq,
     highWaterMark: 4 // reduce memory - default is 16
   })
-
-  return changes.pipe(ndjson.serialize())
 }

--- a/index.js
+++ b/index.js
@@ -18,8 +18,7 @@ var db = levelup(dbPath)
 var core = hypercore(sub(db, 'core'))
 var index = sub(db, 'index')
 var normalize = through2.obj(transform)
-var block = 0
-var feed
+var feed, block
 
 core.list(function (err, keys) {
   if (err) throw err
@@ -34,6 +33,7 @@ core.list(function (err, keys) {
 
   function run (err) {
     if (err) throw err
+    block = feed.blocks
 
     recoverFromBadShutdown(function (err) {
       if (err) throw err

--- a/index.js
+++ b/index.js
@@ -37,9 +37,8 @@ core.list(function (err, keys) {
 
     var stream = feed.createWriteStream()
 
-    index.get('!latest_seq!', function (err, value) {
-      var seq = value || 0
-      if (err && !err.notFound) throw err
+    getNextSeqNo(function (err, seq) {
+      if (err) throw err
       pump(changesSinceStream(seq), normalize, ndjson.serialize(), stream, run)
     })
   }
@@ -85,4 +84,12 @@ function transform (change, env, cb) {
       })
     })
   }
+}
+
+function getNextSeqNo (cb) {
+  index.get('!latest_seq!', function (err, seq) {
+    if (err && err.notFound) cb(null, 0)
+    else if (err) cb(err)
+    else cb(null, parseInt(seq, 10) + 1)
+  })
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict'
 
+var path = require('path')
 var ChangesStream = require('changes-stream')
 var clean = require('normalize-registry-metadata')
 var through2 = require('through2')
@@ -42,7 +43,10 @@ var normalize = through2.obj(function (change, env, cb) {
   }
 })
 
-var db = levelup(process.argv[2] || './npm-to-hypercore.db')
+var dbPath = process.argv[2] || './npm-to-hypercore.db'
+console.log('db location: %s', path.resolve(dbPath))
+
+var db = levelup(dbPath)
 var core = hypercore(sub(db, 'core'))
 var index = sub(db, 'index')
 var block = 0

--- a/index.js
+++ b/index.js
@@ -64,15 +64,15 @@ function transform (change, env, cb) {
 
   clean(doc)
 
-  var ts = doc && doc.time && doc.time.modified
+  var modified = doc && doc.time && doc.time.modified
   var seq = change.seq
 
   if (!doc) {
-    console.log('[%s] skipping %s - invalid document', seq, change.id)
+    console.log('skipping %s - invalid document (seq: %s)', change.id, seq)
     done()
     return
   } else if (!doc.versions || doc.versions.length === 0) {
-    console.log('[%s - %s] skipping %s - no versions detected', ts, seq, change.id)
+    console.log('skipping %s - no versions detected (seq: %s, modified: %s)', change.id, seq, modified)
     done()
     return
   }
@@ -93,7 +93,7 @@ function transform (change, env, cb) {
     index.get(key, function (err) {
       if (!err || !err.notFound) return processVersion(err)
       stream.push(doc.versions[version])
-      if (++block % 10000 === 0) console.log('[%s - %s] processed %d blocks since last restart', ts, seq, block)
+      if (++block % 1000 === 0) console.log('pushed %d blocks (seq: %s, modified: %s)', block, seq, modified)
       index.put(key, true, processVersion)
     })
   }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Stream all of npm metadata into hypercore",
   "bin": "cli.js",
   "dependencies": {
+    "after-all": "^2.0.2",
     "changes-stream": "^2.2.0",
     "hypercore": "^4.19.3",
     "hyperdrive-archive-swarm": "^5.0.5",
@@ -11,6 +12,7 @@
     "ndjson": "^1.5.0",
     "normalize-registry-metadata": "^1.1.2",
     "pump": "^1.0.2",
+    "subleveldown": "^2.1.0",
     "through2": "^2.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "hyperdrive-archive-swarm": "^5.0.5",
     "level": "^1.5.0",
     "ndjson": "^1.5.0",
-    "pump": "^1.0.2"
+    "normalize-registry-metadata": "^1.1.2",
+    "pump": "^1.0.2",
+    "through2": "^2.0.3"
   },
   "devDependencies": {
     "standard": "^8.6.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Stream all of npm metadata into hypercore",
   "bin": "cli.js",
   "dependencies": {
-    "after-all": "^2.0.2",
     "changes-stream": "^2.2.0",
     "hypercore": "^4.19.3",
     "hyperdrive-archive-swarm": "^5.0.5",


### PR DESCRIPTION
Instead of storing the raw change sets from CouchDB, this PR cleans them up and stores the npm package.json docs instead. This ensures that the size of each hypercore block is a more constant size, instead of growing for each release of a specific package.